### PR TITLE
fix:动态路由中，值允许*匹配

### DIFF
--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -741,6 +741,7 @@ type ServiceClusters interface {
 type LocationBasedMetaKey struct {
 	location Location
 	metaKey  string
+	keyType  int // 0: equal, 1: not equal
 }
 
 // metaDataInService 标签缓存信息
@@ -939,7 +940,7 @@ func (c *clusterCache) GetInstanceMetaValues(location Location, metaKey string) 
 func (c *clusterCache) GetInstancesWithMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string {
 	var value interface{}
 	var exists bool
-	locationKey := LocationBasedMetaKey{location: location, metaKey: metaKey}
+	locationKey := LocationBasedMetaKey{location: location, metaKey: metaKey, keyType: 1}
 	value, exists = c.svcLevelMetadata.metaDataSet.Load(locationKey)
 	if exists {
 		return value.(map[string]string)

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -733,6 +733,8 @@ type ServiceClusters interface {
 	GetExtendedCacheValue(pluginIndex int) interface{}
 	// SetExtendedCacheValue 设置扩展的缓存值，需要预初始化好，否则会有并发修改的问题
 	SetExtendedCacheValue(pluginIndex int, value interface{})
+	// GetInstanceMetaValuesNotEqual 获取实例的标签集合，不等于指定meta key
+	GetInstanceMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string
 }
 
 // LocationBasedMetaKey 基于某个地域信息的元数据查询key
@@ -928,6 +930,42 @@ func (c *clusterCache) GetInstanceMetaValues(location Location, metaKey string) 
 			continue
 		}
 		metaValueSet[value] = buildComposedValue(metaKey, value)
+	}
+	value, _ = c.svcLevelMetadata.metaDataSet.LoadOrStore(locationKey, metaValueSet)
+	return value.(map[string]string)
+}
+
+// GetInstanceMetaValuesNotEqual 获取健康实例，不等于标签值
+func (c *clusterCache) GetInstanceMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string {
+	var value interface{}
+	var exists bool
+	locationKey := LocationBasedMetaKey{location: location, metaKey: metaKey}
+	value, exists = c.svcLevelMetadata.metaDataSet.Load(locationKey)
+	if exists {
+		return value.(map[string]string)
+	}
+	// 按需构建指定地域的实例元数据集合
+	instances := c.svcInstances.GetInstances()
+	metaValueSet := make(map[string]string, 0)
+	for _, instance := range instances {
+		if !matchLocation(instance, location) {
+			continue
+		}
+		if instance.IsIsolated() || instance.GetWeight() == 0 || !instance.IsHealthy() {
+			continue
+		}
+		metadata := instance.GetMetadata()
+		if len(metadata) == 0 {
+			continue
+		}
+		val, ok := metadata[metaKey]
+		if !ok {
+			continue
+		}
+		if val == metavalue {
+			continue
+		}
+		metaValueSet[val] = buildComposedValue(metaKey, val)
 	}
 	value, _ = c.svcLevelMetadata.metaDataSet.LoadOrStore(locationKey, metaValueSet)
 	return value.(map[string]string)

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -733,8 +733,8 @@ type ServiceClusters interface {
 	GetExtendedCacheValue(pluginIndex int) interface{}
 	// SetExtendedCacheValue 设置扩展的缓存值，需要预初始化好，否则会有并发修改的问题
 	SetExtendedCacheValue(pluginIndex int, value interface{})
-	// GetInstanceMetaValuesNotEqual 获取实例的标签集合，不等于指定meta key
-	GetInstanceMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string
+	// GetInstancesWithMetaValuesNotEqual 获取该标签不等于指定标签值的实例集合
+	GetInstancesWithMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string
 }
 
 // LocationBasedMetaKey 基于某个地域信息的元数据查询key
@@ -936,7 +936,7 @@ func (c *clusterCache) GetInstanceMetaValues(location Location, metaKey string) 
 }
 
 // GetInstanceMetaValuesNotEqual 获取健康实例，不等于标签值
-func (c *clusterCache) GetInstanceMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string {
+func (c *clusterCache) GetInstancesWithMetaValuesNotEqual(location Location, metaKey string, metavalue string) map[string]string {
 	var value interface{}
 	var exists bool
 	locationKey := LocationBasedMetaKey{location: location, metaKey: metaKey}

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -177,8 +177,14 @@ func (g *RuleBasedInstancesFilter) matchSourceMetadata(ruleMeta map[string]*apim
 					allMetaMatched = false
 				}
 			case apimodel.MatchString_NOT_EQUALS:
+				if rawMetaValue == matchAll {
+					return false, "", nil
+				}
 				allMetaMatched = srcMetaValue != rawMetaValue
 			case apimodel.MatchString_EXACT:
+				if rawMetaValue == matchAll {
+					return true, "", nil
+				}
 				allMetaMatched = srcMetaValue == rawMetaValue
 			case apimodel.MatchString_IN:
 				find := false
@@ -401,7 +407,9 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
 			}
-			if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
+			if ruleMetaValueStr == matchAll {
+				metaChanged = true
+			} else if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {
 					metaChanged = true
 				}

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -402,7 +402,7 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 				return nil, false, "", nil
 			}
 			// 如果全匹配直接标记返回
-			if ruleMetaValueStr == matchAll && ruleMetaValue.Type == apimodel.MatchString_EXACT {
+			if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
 				metaChanged = true
 			} else if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -177,14 +177,8 @@ func (g *RuleBasedInstancesFilter) matchSourceMetadata(ruleMeta map[string]*apim
 					allMetaMatched = false
 				}
 			case apimodel.MatchString_NOT_EQUALS:
-				if rawMetaValue == matchAll {
-					return false, "", nil
-				}
 				allMetaMatched = srcMetaValue != rawMetaValue
 			case apimodel.MatchString_EXACT:
-				if rawMetaValue == matchAll {
-					return true, "", nil
-				}
 				allMetaMatched = srcMetaValue == rawMetaValue
 			case apimodel.MatchString_IN:
 				find := false
@@ -407,7 +401,8 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
 			}
-			if ruleMetaValueStr == matchAll {
+			// 如果全匹配直接标记返回
+			if ruleMetaValueStr == matchAll && ruleMetaValue.Type == apimodel.MatchString_EXACT {
 				metaChanged = true
 			} else if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -453,16 +453,18 @@ func (g *RuleBasedInstancesFilter) getRuleMetaValueStr(routeInfo *servicerouter.
 		if len(srcMeta) == 0 {
 			exist = false
 		} else {
-			if !dst {
-				processedRuleMetaValue, exist = srcMeta[ruleMetaKey]
-				if exist {
-					g.valueCtx.SetValue(ruleMetaKey, processedRuleMetaValue)
-				}
-			} else {
+			// dst 获取需要从上下文中获取请求值
+			// srouce 作为变量识别src标签值，并将值写入上下文
+			if dst {
 				str, ok := g.valueCtx.GetValue(ruleMetaValue.GetValue().GetValue())
 				if ok {
 					processedRuleMetaValue = str.(string)
 					exist = true
+				}
+			} else {
+				processedRuleMetaValue, exist = srcMeta[ruleMetaKey]
+				if exist {
+					g.valueCtx.SetValue(ruleMetaKey, processedRuleMetaValue)
 				}
 			}
 		}

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -158,7 +158,7 @@ func (g *RuleBasedInstancesFilter) matchSourceMetadata(ruleMeta map[string]*apim
 			if ruleMetaValue.GetValue().GetValue() == matchAll {
 				continue
 			}
-			rawMetaValue, exist := g.getRuleMetaValueStr(routeInfo, ruleMetaKey, ruleMetaValue)
+			rawMetaValue, exist := g.getRuleMetaValueStr(routeInfo, ruleMetaKey, ruleMetaValue, false)
 			if !exist {
 				return false, "", nil
 			}
@@ -354,7 +354,7 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 	cls = model.NewCluster(svcCache, inCluster)
 	var metaChanged bool
 	for ruleMetaKey, ruleMetaValue := range ruleMeta {
-		ruleMetaValueStr, exist := g.getRuleMetaValueStr(routeInfo, ruleMetaKey, ruleMetaValue)
+		ruleMetaValueStr, exist := g.getRuleMetaValueStr(routeInfo, ruleMetaKey, ruleMetaValue, true)
 		if !exist {
 			// 首先如果元数据的value无法获取，直接匹配失败
 			return nil, false, "", nil
@@ -438,7 +438,7 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 
 // 获取具体用于匹配的元数据的value
 func (g *RuleBasedInstancesFilter) getRuleMetaValueStr(routeInfo *servicerouter.RouteInfo, ruleMetaKey string,
-	ruleMetaValue *apimodel.MatchString) (string, bool) {
+	ruleMetaValue *apimodel.MatchString, dst bool) (string, bool) {
 	var srcMeta map[string]string
 	if routeInfo.SourceService != nil {
 		srcMeta = routeInfo.SourceService.GetMetadata()
@@ -453,7 +453,18 @@ func (g *RuleBasedInstancesFilter) getRuleMetaValueStr(routeInfo *servicerouter.
 		if len(srcMeta) == 0 {
 			exist = false
 		} else {
-			processedRuleMetaValue, exist = srcMeta[ruleMetaKey]
+			if !dst {
+				processedRuleMetaValue, exist = srcMeta[ruleMetaKey]
+				if exist {
+					g.valueCtx.SetValue(ruleMetaKey, processedRuleMetaValue)
+				}
+			} else {
+				str, ok := g.valueCtx.GetValue(ruleMetaValue.GetValue().GetValue())
+				if ok {
+					processedRuleMetaValue = str.(string)
+					exist = true
+				}
+			}
 		}
 	case apimodel.MatchString_VARIABLE:
 		processedRuleMetaValue, exist = g.getVariable(ruleMetaValue.GetValue().GetValue())

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -359,7 +359,10 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			// 首先如果元数据的value无法获取，直接匹配失败
 			return nil, false, "", nil
 		}
-
+		// 全匹配类型直接返回全量实例
+		if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
+			return cls, true, "", nil
+		}
 		// 如果类型是不等于，那应该单独获取实例
 		var metaValues map[string]string
 		if ruleMetaValue.Type != apimodel.MatchString_NOT_EQUALS {
@@ -369,7 +372,6 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 				return nil, false, "", nil
 			}
 		}
-
 		switch ruleMetaValue.Type {
 		case apimodel.MatchString_REGEX:
 			// 对于正则表达式，则可能匹配到多个value，
@@ -417,9 +419,6 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			// 校验从上一个路由插件继承下来的规则是否符合该目标规则
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
-			}
-			if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
-				return cls, true, "", nil
 			}
 			if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -359,11 +359,17 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			// 首先如果元数据的value无法获取，直接匹配失败
 			return nil, false, "", nil
 		}
-		metaValues := svcCache.GetInstanceMetaValues(cls.Location, ruleMetaKey)
-		if len(metaValues) == 0 {
-			// 不匹配
-			return nil, false, "", nil
+
+		// 如果类型是不等于，那应该单独获取实例
+		var metaValues map[string]string
+		if ruleMetaValue.Type != apimodel.MatchString_NOT_EQUALS {
+			metaValues = svcCache.GetInstanceMetaValues(cls.Location, ruleMetaKey)
+			if len(metaValues) == 0 {
+				// 不匹配
+				return nil, false, "", nil
+			}
 		}
+
 		switch ruleMetaValue.Type {
 		case apimodel.MatchString_REGEX:
 			// 对于正则表达式，则可能匹配到多个value，
@@ -395,16 +401,27 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			if !hasMatchedValue {
 				return nil, false, "", nil
 			}
+
+		case apimodel.MatchString_NOT_EQUALS:
+			metaValues = svcCache.GetInstanceMetaValuesNotEqual(cls.Location, ruleMetaKey, ruleMetaValueStr)
+			if len(metaValues) == 0 {
+				return cls, false, "", nil
+			}
+			for k, v := range metaValues {
+				cls.RuleAddMetadata(ruleMetaKey, k, v)
+			}
+			metaChanged = true
+
 		// parameter、variable、text 的 exact 最终都是要精确匹配，只是匹配的值来源不同
 		default:
 			// 校验从上一个路由插件继承下来的规则是否符合该目标规则
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
 			}
-			// 如果全匹配直接标记返回
 			if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
-				metaChanged = true
-			} else if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
+				return cls, true, "", nil
+			}
+			if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {
 					metaChanged = true
 				}
@@ -604,7 +621,7 @@ func (g *RuleBasedInstancesFilter) getRuleFilteredInstances(ruleMatchType int, r
 	}
 	for _, route := range routes {
 		// 匹配source规则
-		sourceMatched, match, notMatches, invalidRegex := g.matchSource(route.Sources, routeInfo, ruleMatchType, ruleCache)
+		sourceMatched, match, notMatches, invalidRegex := g.matchSource(route.GetSources(), routeInfo, ruleMatchType, ruleCache)
 
 		if invalidRegex != nil {
 			// summary.invalidRegexSources = append(summary.invalidRegexSources, invalidRegex.invalidRegexes...)

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -405,7 +405,7 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			}
 
 		case apimodel.MatchString_NOT_EQUALS:
-			metaValues = svcCache.GetInstanceMetaValuesNotEqual(cls.Location, ruleMetaKey, ruleMetaValueStr)
+			metaValues = svcCache.GetInstancesWithMetaValuesNotEqual(cls.Location, ruleMetaKey, ruleMetaValueStr)
 			if len(metaValues) == 0 {
 				return cls, false, "", nil
 			}


### PR DESCRIPTION
Please provide issue(s) of this PR:
动态路由中，支持destination的值'*'匹配